### PR TITLE
Add podcast to Podcast section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1926,6 +1926,7 @@ Here are some blogs and newsletter I follow.
     - Part organizational design. Part therapy. Organizational psychologist and Stanford Professor Bob Sutton is back to tackle friction, the phenomenon that frustrates employees, fatigues teams and causes organizations to flounder and fail.
 - [CTO Insights with Katerina Trajchevska](https://ctoinsights.adevait.com/). A great podcast on all things CTO—featuring thoughtful conversations with tech leaders like DHH (Basecamp), Kent Beck (Agile Manifesto), and more.
 - [The Pragmatic Engineer Podcast with Gergely Orosz](https://newsletter.pragmaticengineer.com/podcast)  This podcast features candid conversations with senior engineering leaders from top tech companies. Topics include scaling teams, navigating hypergrowth, building resilient systems, and leading with impact—grounded in real-world experience.
+- [Chain of Thought](https://chainofthought.show/). A weekly AI podcast exploring tech leadership, AI strategy, and engineering culture through conversations with industry leaders.
 
 ## My other lists
 


### PR DESCRIPTION
Adds Chain of Thought to the Podcast section. Weekly AI podcast covering tech leadership, AI strategy, and engineering culture.

https://chainofthought.show/