### PR TITLE
Fix(Broken HBR Link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ I don't necessarily agree with everything listed here. Actually, you'll see that
 - [Tool: Hold effective 1:1 meetings](https://rework.withgoogle.com/guides/managers-coach-managers-to-coach/steps/hold-effective-1-1-meetings/)
 - [21 Reasons You Should Start Having One on Ones with Your Team](https://jasonevanish.com/2014/05/21/21-reasons-you-should-start-having-one-on-ones-with-your-team/)
 - [What is an Inquiring Leader?](https://www.linkedin.com/pulse/what-inquiring-leader-marilee-adams)
-- HBR, [How to Ask Better Questions](https://hbr.org/2009/05/real-leaders-ask.html)
+- HBR, [How to Ask Better Questions](https://hbr.org/2009/05/real-leaders-ask)
 - [Mentor vs Advisor vs Coach](http://baxterblog.typepad.com/blog/2012/11/mentor-vs-advisor-vs-coach.html)
 - [How To Be Someone People Love To Talk To](http://www.bakadesuyo.com/2015/02/love-to-talk/)
 - 🧰 [Mega list of 1 on 1 meeting questions compiled from a variety to sources](https://github.com/VGraupera/1on1-questions)


### PR DESCRIPTION
## Issue
HBR's "How to Ask Better Questions" article link had `.html` at the end which was preventing HBR from showing the page. 

## Fix
Verified fix by removing the file-type from the link text.

## Reference
**Screenshot of HBR with existing URL, showing 404 message.** 
<img width="1183" height="865" alt="image" src="https://github.com/user-attachments/assets/ef76c33a-bc43-4cae-92de-56b3b26c3307" />


**Screenshot of HBR with corrected URL**
<img width="1024" height="773" alt="Screenshot From 2026-05-18 08-44-58" src="https://github.com/user-attachments/assets/23bd7605-7cca-4446-990a-a4a023b98da1" />
