### PR TITLE
Add "You're Measuring AI Spend, Not AI Value" to Developer productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,10 @@ See also the section about [Organizational structure](#organizational-structure)
   - Quantify the business value of projects
 - [Measuring Developer Productivity via Humans](https://martinfowler.com/articles/measuring-developer-productivity-humans.html), Martin Fowler
 - [2024 DORA report](https://services.google.com/fh/files/misc/2024_final_dora_report.pdf)
+- [You're Measuring AI Spend, Not AI Value](https://sawinyh.com/blog/measuring-ai-spend-not-value/): AI broke velocity and lines-of-code as proxies. Proposes cost-per-verified-outcome (CPVO) for governing AI dev-tool spend.
+  - Cost-per-verified-outcome (CPVO): team-tagged AI spend divided by outcomes that shipped and stayed shipped
+  - Review tax: the human and machine review cost AI-generated code pushes downstream
+  - Verified share and a four-cut team dashboard, kept at team altitude to avoid per-person leaderboards
 
 ### Diversity and inclusion
 


### PR DESCRIPTION
Adds one entry to the **Developer productivity and devexp** section:

* [You're Measuring AI Spend, Not AI Value](https://sawinyh.com/blog/measuring-ai-spend-not-value/)

## Why it fits

The section already collects work on measuring developer productivity (Martin Fowler's "Measuring Developer Productivity via Humans", the DORA report, "DevEx: What Actually Drives Productivity"). This piece extends that to the AI era: it argues velocity and lines-of-code stopped working as proxies once AI entered the loop, and proposes **cost-per-verified-outcome (CPVO)** — team-tagged AI spend divided by outcomes that shipped and stayed shipped — plus review-tax and verified-share as a team-level dashboard. It deliberately keeps measurement at team altitude to avoid per-person leaderboards, which also connects to the repo's FinOps (cost) theme.

Single-line addition (with sub-bullets matching the section's existing style); no other entries touched.